### PR TITLE
Checks if Ollama is reachable

### DIFF
--- a/utils.zsh
+++ b/utils.zsh
@@ -60,22 +60,9 @@ check_command() {
 
 # Function to check if Ollama is running
 check_ollama_running() {
-    local os=$(detect_os)
-    case "$os" in
-        "linux"|"mac")
-            if ! pgrep -f ollama &> /dev/null; then
-                if [ "$os" = "mac" ]; then
-                    echo "🚨 Ollama server not running! Start it with: brew services start ollama"
-                else
-                    echo "🚨 Ollama server not running! Start it with: sudo systemctl start ollama"
-                fi
-                return 1
-            fi
-            ;;
-        *)
-            echo "🚨 Unsupported operating system for Ollama"
-            return 1
-            ;;
-    esac
+    if ! curl -s "$KOLLZSH_URL" | grep -q "Ollama is running"; then
+        echo "🚨 Ollama server not running at $KOLLZSH_URL!"
+        return 1
+    fi
     return 0
 }


### PR DESCRIPTION
This actually checks if ollama is running and reachable rather than just running on the local system. Useful with KOLLZH_URL and if the Ollama service hangs/dies but the process is alive.